### PR TITLE
Add support quota key query

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Clickhouse supports setting
 [quota_key](https://clickhouse.yandex/docs/en/operations/quotas/) for each
 query. The database driver provides ability to set these parameters as well.
 
+There are constants `QueryID` and `QuotaKey` for correct setting these params.
+
 `quota_key` could be set as empty string, but `query_id` - does not. Keep in
 mind, that setting same `query_id` could produce exception or replace already
 running query depending on current Clickhouse settings. See
@@ -176,7 +178,7 @@ func main() {
 	}
 
 	ctx := context.Background()
-	rows, err := connect.QueryContext(context.WithValue(ctx, "query_id", "dummy-query-id"), `
+	rows, err := connect.QueryContext(context.WithValue(ctx, clickhouse.QueryID, "dummy-query-id"), `
 		SELECT
 			country_code,
 			os_id,

--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ type `[]byte` are used as raw string (without quoting)
 for passing value of type `[]uint8` to driver as array - please use the wrapper `clickhouse.Array`
 for passing decimal value please use the wrappers `clickhouse.Decimal*`
 
+## Supported request params
+
+Clickhouse supports setting
+[query_id](https://clickhouse.yandex/docs/en/interfaces/http/) and
+[quota_key](https://clickhouse.yandex/docs/en/operations/quotas/) for each
+query. The database driver provides ability to set these parameters as well.
+
+`quota_key` could be set as empty string, but `query_id` - does not. Keep in
+mind, that setting same `query_id` could produce exception or replace already
+running query depending on current Clickhouse settings. See
+[replace_running_query](https://clickhouse.yandex/docs/en/operations/settings/settings/#replace-running-query)
+for details.
+
+See `Example` section for use cases.
+
 ## Install
 ```
 go get -u github.com/mailru/go-clickhouse
@@ -54,6 +69,7 @@ go get -u github.com/mailru/go-clickhouse
 package main
 
 import (
+	"context"
 	"database/sql"
 	"log"
 	"time"
@@ -124,6 +140,44 @@ func main() {
 
 	rows, err := connect.Query(`
 		SELECT 
+			country_code,
+			os_id,
+			browser_id,
+			categories,
+			action_day,
+			action_time
+		FROM
+			example`)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for rows.Next() {
+		var (
+			country               string
+			os, browser           uint8
+			categories            []int16
+			actionDay, actionTime time.Time
+		)
+		if err := rows.Scan(
+			&country,
+			&os,
+			&browser,
+			&categories,
+			&actionDay,
+			&actionTime,
+		); err != nil {
+			log.Fatal(err)
+		}
+		log.Printf("country: %s, os: %d, browser: %d, categories: %v, action_day: %s, action_time: %s",
+			country, os, browser, categories, actionDay, actionTime,
+		)
+	}
+
+	ctx := context.Background()
+	rows, err := connect.QueryContext(context.WithValue(ctx, "query_id", "dummy-query-id"), `
+		SELECT
 			country_code,
 			os_id,
 			browser_id,

--- a/conn.go
+++ b/conn.go
@@ -15,9 +15,16 @@ import (
 	"time"
 )
 
+type key int
+
 const (
-	QueryID  = "query_id"
-	QuotaKey = "quota_key"
+	// QueryID uses for setting query_id request param for request to Clickhouse
+	QueryID key = iota
+	// QuotaKey uses for setting quota_key request param for request to Clickhouse
+	QuotaKey
+
+	quotaKeyParamName = "quota_key"
+	queryIDParamName  = "query_id"
 )
 
 // conn implements an interface sql.Conn
@@ -249,11 +256,11 @@ func (c *conn) buildRequest(ctx context.Context, query string, params []driver.V
 		reqQuery := req.URL.Query()
 		quotaKey, ok := ctx.Value(QuotaKey).(string)
 		if ok {
-			reqQuery.Add(QuotaKey, quotaKey)
+			reqQuery.Add(quotaKeyParamName, quotaKey)
 		}
 		queryID, ok := ctx.Value(QueryID).(string)
 		if ok && len(queryID) > 0 {
-			reqQuery.Add(QueryID, queryID)
+			reqQuery.Add(queryIDParamName, queryID)
 		}
 		req.URL.RawQuery = reqQuery.Encode()
 	}

--- a/conn.go
+++ b/conn.go
@@ -15,6 +15,11 @@ import (
 	"time"
 )
 
+const (
+	QueryID  = "query_id"
+	QuotaKey = "quota_key"
+)
+
 // conn implements an interface sql.Conn
 type conn struct {
 	url                *url.URL
@@ -242,13 +247,13 @@ func (c *conn) buildRequest(ctx context.Context, query string, params []driver.V
 	}
 	if ctx != nil {
 		reqQuery := req.URL.Query()
-		quotaKey, ok := ctx.Value("quota_key").(string)
+		quotaKey, ok := ctx.Value(QuotaKey).(string)
 		if ok {
-			reqQuery.Add("quota_key", quotaKey)
+			reqQuery.Add(QuotaKey, quotaKey)
 		}
-		queryId, ok := ctx.Value("query_id").(string)
-		if ok && len(queryId) > 0 {
-			reqQuery.Add("query_id", queryId)
+		queryID, ok := ctx.Value(QueryID).(string)
+		if ok && len(queryID) > 0 {
+			reqQuery.Add(QueryID, queryID)
 		}
 		req.URL.RawQuery = reqQuery.Encode()
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -202,7 +202,7 @@ func (s *connSuite) TestBuildRequestReadWriteWOAuth() {
 func (s *connSuite) TestBuildRequestWithQueryId() {
 	cn := newConn(NewConfig())
 	testCases := []struct {
-		queryId  string
+		queryID  string
 		expected string
 	}{
 		{
@@ -231,7 +231,7 @@ func (s *connSuite) TestBuildRequestWithQueryId() {
 		},
 	}
 	for _, tc := range testCases {
-		req, err := cn.buildRequest(context.WithValue(context.Background(), "query_id", tc.queryId), "INSERT 1 INTO num", nil, false)
+		req, err := cn.buildRequest(context.WithValue(context.Background(), QueryID, tc.queryID), "INSERT 1 INTO num", nil, false)
 		if s.NoError(err) {
 			s.Equal(http.MethodPost, req.Method)
 			s.Equal(tc.expected, req.URL.String())
@@ -270,7 +270,7 @@ func (s *connSuite) TestBuildRequestWithQuotaKey() {
 		},
 	}
 	for _, tc := range testCases {
-		req, err := cn.buildRequest(context.WithValue(context.Background(), "quota_key", tc.quotaKey), "INSERT 1 INTO num", nil, false)
+		req, err := cn.buildRequest(context.WithValue(context.Background(), QuotaKey, tc.quotaKey), "INSERT 1 INTO num", nil, false)
 		if s.NoError(err) {
 			s.Equal(http.MethodPost, req.Method)
 			s.Equal(tc.expected, req.URL.String())
@@ -281,7 +281,7 @@ func (s *connSuite) TestBuildRequestWithQueryIdAndQuotaKey() {
 	cn := newConn(NewConfig())
 	testCases := []struct {
 		quotaKey string
-		queryId  string
+		queryID  string
 		expected string
 	}{
 		{
@@ -317,8 +317,8 @@ func (s *connSuite) TestBuildRequestWithQueryIdAndQuotaKey() {
 	}
 	for _, tc := range testCases {
 		ctx := context.Background()
-		ctx = context.WithValue(ctx, "quota_key", tc.quotaKey)
-		ctx = context.WithValue(ctx, "query_id", tc.queryId)
+		ctx = context.WithValue(ctx, QuotaKey, tc.quotaKey)
+		ctx = context.WithValue(ctx, QueryID, tc.queryID)
 		req, err := cn.buildRequest(ctx, "INSERT 1 INTO num", nil, false)
 		if s.NoError(err) {
 			s.Equal(http.MethodPost, req.Method)

--- a/conn_test.go
+++ b/conn_test.go
@@ -1,6 +1,7 @@
 package clickhouse
 
 import (
+	"context"
 	"database/sql"
 	"database/sql/driver"
 	"net/http"
@@ -175,7 +176,7 @@ func (s *connSuite) TestBuildRequestReadonlyWithAuth() {
 	cfg.User = "user"
 	cfg.Password = "password"
 	cn := newConn(cfg)
-	req, err := cn.buildRequest("SELECT 1", nil, true)
+	req, err := cn.buildRequest(context.Background(), "SELECT 1", nil, true)
 	if s.NoError(err) {
 		user, password, ok := req.BasicAuth()
 		s.True(ok)
@@ -189,7 +190,7 @@ func (s *connSuite) TestBuildRequestReadonlyWithAuth() {
 
 func (s *connSuite) TestBuildRequestReadWriteWOAuth() {
 	cn := newConn(NewConfig())
-	req, err := cn.buildRequest("INSERT 1 INTO num", nil, false)
+	req, err := cn.buildRequest(context.Background(), "INSERT 1 INTO num", nil, false)
 	if s.NoError(err) {
 		_, _, ok := req.BasicAuth()
 		s.False(ok)
@@ -198,6 +199,133 @@ func (s *connSuite) TestBuildRequestReadWriteWOAuth() {
 	}
 }
 
+func (s *connSuite) TestBuildRequestWithQueryId() {
+	cn := newConn(NewConfig())
+	testCases := []struct {
+		queryId  string
+		expected string
+	}{
+		{
+			"",
+			cn.url.String(),
+		},
+		{
+			"query-id",
+			cn.url.String() + "&query_id=query-id",
+		},
+		{
+			"query id",
+			cn.url.String() + "&query_id=query+id",
+		},
+		{
+			" ",
+			cn.url.String() + "&query_id=+",
+		},
+		{
+			"_",
+			cn.url.String() + "&query_id=_",
+		},
+		{
+			"^",
+			cn.url.String() + "&query_id=%5E",
+		},
+	}
+	for _, tc := range testCases {
+		req, err := cn.buildRequest(context.WithValue(context.Background(), "query_id", tc.queryId), "INSERT 1 INTO num", nil, false)
+		if s.NoError(err) {
+			s.Equal(http.MethodPost, req.Method)
+			s.Equal(tc.expected, req.URL.String())
+		}
+	}
+}
+func (s *connSuite) TestBuildRequestWithQuotaKey() {
+	cn := newConn(NewConfig())
+	testCases := []struct {
+		quotaKey string
+		expected string
+	}{
+		{
+			"",
+			cn.url.String() + "&quota_key=",
+		},
+		{
+			"quota-key",
+			cn.url.String() + "&quota_key=quota-key",
+		},
+		{
+			"quota key",
+			cn.url.String() + "&quota_key=quota+key",
+		},
+		{
+			" ",
+			cn.url.String() + "&quota_key=+",
+		},
+		{
+			"_",
+			cn.url.String() + "&quota_key=_",
+		},
+		{
+			"^",
+			cn.url.String() + "&quota_key=%5E",
+		},
+	}
+	for _, tc := range testCases {
+		req, err := cn.buildRequest(context.WithValue(context.Background(), "quota_key", tc.quotaKey), "INSERT 1 INTO num", nil, false)
+		if s.NoError(err) {
+			s.Equal(http.MethodPost, req.Method)
+			s.Equal(tc.expected, req.URL.String())
+		}
+	}
+}
+func (s *connSuite) TestBuildRequestWithQueryIdAndQuotaKey() {
+	cn := newConn(NewConfig())
+	testCases := []struct {
+		quotaKey string
+		queryId  string
+		expected string
+	}{
+		{
+			"",
+			"",
+			cn.url.String() + "&quota_key=",
+		},
+		{
+			"quota-key",
+			"query-id",
+			cn.url.String() + "&query_id=query-id&quota_key=quota-key",
+		},
+		{
+			"quota key",
+			"query id",
+			cn.url.String() + "&query_id=query+id&quota_key=quota+key",
+		},
+		{
+			" ",
+			" ",
+			cn.url.String() + "&query_id=+&quota_key=+",
+		},
+		{
+			"_",
+			"_",
+			cn.url.String() + "&query_id=_&quota_key=_",
+		},
+		{
+			"^",
+			"&query",
+			cn.url.String() + "&query_id=%26query&quota_key=%5E",
+		},
+	}
+	for _, tc := range testCases {
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, "quota_key", tc.quotaKey)
+		ctx = context.WithValue(ctx, "query_id", tc.queryId)
+		req, err := cn.buildRequest(ctx, "INSERT 1 INTO num", nil, false)
+		if s.NoError(err) {
+			s.Equal(http.MethodPost, req.Method)
+			s.Equal(tc.expected, req.URL.String())
+		}
+	}
+}
 func TestConn(t *testing.T) {
 	suite.Run(t, new(connSuite))
 }


### PR DESCRIPTION
The PR adds support of `quota_key` and` query_id` for queries to Clickhouse for the driver.

Info about these Clickhouse settings could be found on official website - [quotas](https://clickhouse.yandex/docs/en/operations/quotas/) and [query_id](https://clickhouse.yandex/docs/en/interfaces/http/).

Keep in mind, that for reading info which `quota_key` or `query_id` was used for particular query, you should enable `log_queries` setting. Moreover, setting up `query_id` could potentially [replace executing query with the same id](https://clickhouse.yandex/docs/en/operations/settings/settings/#replace-running-query), which is depending on server settings.

I also added README instruction for supported params as well as tests. Feel free to send any comments and thoughts.